### PR TITLE
replace `echo -n` with `printf` for POSIX compatibility

### DIFF
--- a/capdl.mk
+++ b/capdl.mk
@@ -57,14 +57,14 @@ specs: $(SEL4_SPECS) $(SEL4_MODULE_SPECS)
 
 $(SEL4_SPECS): $(CAPDL_SPECS)
 	$(Q) file=$@ ;\
-	echo -n "[STAGE/SPEC] "; echo -n "/$${file#$(SEL4_SPECDIR)/}"; \
+	printf "[STAGE/SPEC] "; printf "/$${file#$(SEL4_SPECDIR)/}"; \
 	if [ -d $${file#$(STAGE_BASE)/} ]; then echo "/*"; else echo ""; fi; \
 	mkdir -p `dirname $$file`; \
 	cp -a ${CAPDL_SPECDIR}/$${file#${SEL4_SPECDIR}/} `dirname $$file`  ;
 
 ${SEL4_SPECDIR}/modules/%/module.spec: ${SEL4_MODULES_PATH}/%/module.spec
 	$(Q) file=$@; \
-	echo -n "[STAGE/SPEC] "; echo "$${file#${SEL4_SPECDIR}/modules/}"; \
+	printf "[STAGE/SPEC] "; echo "$${file#${SEL4_SPECDIR}/modules/}"; \
 	mkdir -p `dirname $$file` ; \
 	cp -a ${SEL4_MODULES_PATH}/$${file#${SEL4_SPECDIR}/modules/} $$file ;
 
@@ -87,7 +87,7 @@ $(SEL4_SYSTEM_CAPDL): specs dm
 	@echo "[GEN_CAPDL_SPEC] done."
 $(BUILD_BASE)/capDL-loader/archive.o: export TOOLPREFIX=$(CONFIG_CROSS_COMPILER_PREFIX:"%"=%)
 $(BUILD_BASE)/capDL-loader/archive.o: $(SEL4_SYSTEM_CAPDL)
-	@echo -n "[CPIO ARCHIVE]"
+	@printf "[CPIO ARCHIVE]"
 	$(Q)mkdir -p $(dir $@)
 	@echo -e $(patsubst %,"\\n   [CPIO] % ",$(filter-out capDL-loader,$(modules)))
 	$(Q)${COMMON_PATH}/files_to_obj.sh $@ _capdl_archive $(patsubst %,$(STAGE_BASE)/bin/%,$(notdir $(filter-out capDL-loader, $(modules))));

--- a/common.mk
+++ b/common.mk
@@ -209,7 +209,7 @@ install-headers:
 		mkdir -p $(SEL4_INCLUDEDIR) ; \
 		echo " [HEADERS]"; \
 		for file in $(HDRFILES); do \
-			echo -n " [STAGE] "; echo -n `basename $$file`; \
+			printf " [STAGE] "; printf `basename $$file`; \
 			if [ -d $$file ]; then echo "/*"; else echo; fi; \
 			cp -aL $$file $(SEL4_INCLUDEDIR) ; \
 		done; \
@@ -222,7 +222,7 @@ install-headers:
 			dest=$(SEL4_INCLUDEDIR)/`echo "$$hdrfile" | sed 's/^.*[ \t]\([^ \t]*\)$$/\1/'` ; \
 			mkdir -p $$dest; \
 			cp -a $$source $$dest ; \
-			echo -n " [STAGE]"; basename $$dest; \
+			printf " [STAGE]"; basename $$dest; \
 		done ; \
 	fi
 

--- a/project.mk
+++ b/project.mk
@@ -239,7 +239,7 @@ all: .config kernel_elf
 
 cp_if_changed = \
 	@set -e; $(echo-cmd)  \
-	cmp -s $(1) $(2) || (cp $(1) $(2) && echo -n ' '; echo -n '[STAGE] '; basename $(2);)
+	cmp -s $(1) $(2) || (cp $(1) $(2) && printf ' '; printf '[STAGE] '; basename $(2);)
 
 $(KBUILD_ROOT)/.config: .config
 	$(Q)mkdir -p $(KBUILD_ROOT)


### PR DESCRIPTION
/bin/sh on OS X notably lacks support for `echo -n`, and `echo -n` is
explicitly defined as not-portable by the POSIX standard. On shells
whose echo lacks the `-n` flag, make output is garbled:

```
[libs/libsel4utils] building...
 [HEADERS]
 -n  [STAGE]
 -n sel4utils
```

Replace all instances of `echo -n` with `printf`, which is
POSIX-compatible.
