### PR TITLE
OS X support

### DIFF
--- a/files_to_obj.sh
+++ b/files_to_obj.sh
@@ -26,11 +26,10 @@ if [ $# -lt 2 ]; then
     exit 1
 fi
 
-# Get the absolute path of $1. Unfortunately realpath, which seems the most
-# portable option here, only works on existing files.
-touch "$1"
-OUTPUT_FILE=$(realpath "$1")
-rm "$1"
+# Get the absolute path of $1. Unfortunately realpath, which seems the
+# cleanest, most portable option here, doesn't yet ship with all
+# systems.
+OUTPUT_FILE="$(cd "$(dirname "$1")"; pwd -P)/$1"
 
 SYMBOL=$2
 shift 2

--- a/project.mk
+++ b/project.mk
@@ -251,7 +251,10 @@ setup: $(AUTOCONF_H_FILE)
 
 PHONY += common
 common: setup
-	$(Q)cp -ur $(TOOLS_ROOT)/$@ $(STAGE_BASE)
+# Copy only the non-hidden contents of tools/common, since some cp
+# invocations can't overwrite the symlinks in .git.
+	$(Q)mkdir -p $(STAGE_BASE)/$@
+	$(Q)cp -R $(TOOLS_ROOT)/$@/* $(STAGE_BASE)/$@
 
 export SEL4_COMMON=$(STAGE_BASE)/common
 

--- a/project.mk
+++ b/project.mk
@@ -312,7 +312,7 @@ clean:
 # if the only files in include are the Kconfig ones, then this should work silently
 # otherwise it should fail
 	@if [ -d include ]; then echo " [INCLUDE] $(PWD)/include"; \
-		rmdir --ignore-fail-on-non-empty include > /dev/null 2>&1; fi
+		rmdir include > /dev/null 2>&1 || true; fi
 
 PHONY += clobber
 clobber: clean


### PR DESCRIPTION
Per our conversation in #1, I figured I'd take a stab at removing the dependency on GNU coreutils, and it turned out to be fairly clean.

Caveats:
- `cp -u` has been replaced with a bare `cp` and is thus theoretically slower; we waste cycles copying all files every time. But there's no measurable impact on my build times.
