### PR TITLE
Add a separate elf ARCHIVES link rule.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -263,16 +263,23 @@ endif
 	$(Q)$(CC) $(ASFLAGS) $(CPPFLAGS) -c $< -o $@
 
 %.a: $(OBJFILES)
-	@echo " [AR] $@"
+	@echo " [AR] $@ objs:$(OBJFILES)"
 	$(Q)mkdir -p $(dir $@)
 	$(Q)$(AR) r $@ $(OBJFILES) > /dev/null 2>&1
 
 %.bin: %.elf
 	$(call cp_file,$<,$@)
 
+# Note: Create a separate rule ARCHIVES to clearly indicate they
+# the ARCHIVES must be built before doing any other steps. Previously
+# when ARCHIVES was a prerequisite on the line below make thought
+# it was local to this directory and would make the archives using
+# src/main.obj.
+%.elf: $(ARCHIVES)
+
 # Note: below the CC line does not have ARCHIVES because
 # LDFLAGS already includes the "-l" version of ARCHIVES
-%.elf: $(CRTOBJFILES) $(FINOBJFILES) $(OBJFILES) $(ARCHIVES)
+%.elf: $(CRTOBJFILES) $(FINOBJFILES) $(OBJFILES)
 	@echo " [LINK] $@"
 	$(Q)mkdir -p $(dir $@)
 	$(Q)$(CC) $(CRTOBJFILES) $(OBJFILES) $(FINOBJFILES) $(LDFLAGS) -o $@


### PR DESCRIPTION
ARCHIVES dependency needs to be a separate rule so vpath is used for
finding the ARCHIVES.

The first time building the system after a "make clean" there are no
issues, everything works as expected. Here is an snippet of the make
output of a simple helloworld linking against some libraries.

 [apps/helloworld] building...
 [HEADERS]
 [STAGE] autoconf.h
 [CC] src/main.o
 [LINK] helloworld.elf
 [STAGE] helloworld.bin
 [STAGE] helloworld
 [apps/helloworld] done.

If we now change a file which is a member of a library, gmake will
actually create a local version of all of the libraries with the content
of $(OBJFILES). But, the resulting helloworld.elf is correct because
the ARCHIVES are not the local versions, but the ones defined by the -L/-l
options in LDFLAGS. Below you can see the local versions of the AR being
created, all with the same content:

 [apps/helloworld] building...
  [HEADERS]
  [STAGE] autoconf.h
  [CC] src/main.o
  [AR] libsel4.a objs: src/main.o
  [AR] libsel4string.a objs: src/main.o
  [AR] libsel4assert.a objs: src/main.o
  [AR] libsel4printf.a objs: src/main.o
  [AR] libsel4putchar.a objs: src/main.o
  [AR] libsel4startstop.a objs: src/main.o
  [LINK] helloworld.elf
  [STAGE] helloworld.bin
  [STAGE] helloworld
 [apps/helloworld] done.

Finally, if you change the file in the library one or more times no
linking of helloworld.elf will occur since the local versions now satisfy
the rule, thus the results will not contain any changes, even though the
library was rebuilt:

 [apps/helloworld] building...
  [HEADERS]
  [STAGE] autoconf.h
 [apps/helloworld] done.
